### PR TITLE
chore: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
 
       # Validate wrapper
       - name: Gradle Wrapper Validation
-        uses: gradle/wrapper-validation-action@v3
+        uses: gradle/wrapper-validation-action@f9c9c575b8b21b6485636a91ffecd10e558c62f6 # v3.5.0
 
       # Set up Java environment for the next steps
       - name: Setup Java
@@ -53,7 +53,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           gradle-home-cache-cleanup: true
 
@@ -117,7 +117,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           gradle-home-cache-cleanup: true
 
@@ -135,7 +135,7 @@ jobs:
 
       # Upload the Kover report to CodeCov
       - name: Upload Code Coverage Report
-        uses: codecov/codecov-action@v5
+        uses: codecov/codecov-action@75cd11691c0faa626561e295848008c8a7dddffe # v5.5.4
         with:
           files: ${{ github.workspace }}/build/reports/kover/report.xml
 
@@ -152,7 +152,7 @@ jobs:
 
       # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false
@@ -170,7 +170,7 @@ jobs:
 
       # Run Qodana inspections
       - name: Qodana - Code Inspection
-        uses: JetBrains/qodana-action@v2024.3.4
+        uses: JetBrains/qodana-action@b60a4b9259f448dd00f2ca4763db5677d69ba868 # v2024.3.4
         with:
           cache-default-branch-only: true
 
@@ -188,7 +188,7 @@ jobs:
 
       # Free GitHub Actions Environment Disk Space
       - name: Maximize Build Space
-        uses: jlumbroso/free-disk-space@main
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
         with:
           tool-cache: false
           large-packages: false
@@ -206,7 +206,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           gradle-home-cache-cleanup: true
 

--- a/.github/workflows/run-ui-tests.yml
+++ b/.github/workflows/run-ui-tests.yml
@@ -44,7 +44,7 @@ jobs:
 
       # Setup Gradle
       - name: Setup Gradle
-        uses: gradle/actions/setup-gradle@v4
+        uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a # v4.4.3
         with:
           gradle-home-cache-cleanup: true
 
@@ -54,7 +54,7 @@ jobs:
 
       # Wait for IDEA to be started
       - name: Health Check
-        uses: jtalk/url-health-check-action@v4
+        uses: jtalk/url-health-check-action@b716ccb6645355dd9fcce8002ce460e5474f7f00 # v4
         with:
           url: http://127.0.0.1:8082
           max-attempts: 15


### PR DESCRIPTION
Pins third-party GitHub Actions in this repo to immutable commit SHAs.

This PR was prepared with agent assistance and manually verified.

Tracking: DEVPROD-1072

Repo-level summary:
- Pinned distinct third-party action refs in this PR: 6
- Repo-level unpinned usage count from the trunk recheck: 11
- Dependabot GitHub Actions coverage: already_present (.github/dependabot.yml)


Known label limitations:
- `jtalk/url-health-check-action` keeps `# v4` because no more specific same-major tag was found.

Verification commands:

```bash
# codecov/codecov-action # v5.5.4 -> 75cd11691c0faa626561e295848008c8a7dddffe
gh api repos/codecov/codecov-action/commits/v5.5.4 --jq '.sha'
# expected: 75cd11691c0faa626561e295848008c8a7dddffe

# gradle/actions/setup-gradle # v4.4.3 -> ed408507eac070d1f99cc633dbcf757c94c7933a
gh api repos/gradle/actions/commits/v4.4.3 --jq '.sha'
# expected: ed408507eac070d1f99cc633dbcf757c94c7933a

# gradle/wrapper-validation-action # v3.5.0 -> f9c9c575b8b21b6485636a91ffecd10e558c62f6
gh api repos/gradle/wrapper-validation-action/commits/v3.5.0 --jq '.sha'
# expected: f9c9c575b8b21b6485636a91ffecd10e558c62f6

# JetBrains/qodana-action # v2024.3.4 -> b60a4b9259f448dd00f2ca4763db5677d69ba868
gh api repos/JetBrains/qodana-action/commits/v2024.3.4 --jq '.sha'
# expected: b60a4b9259f448dd00f2ca4763db5677d69ba868

# jlumbroso/free-disk-space # v1.3.1 -> 54081f138730dfa15788a46383842cd2f914a1be
gh api repos/jlumbroso/free-disk-space/commits/v1.3.1 --jq '.sha'
# expected: 54081f138730dfa15788a46383842cd2f914a1be

# jtalk/url-health-check-action # v4 -> b716ccb6645355dd9fcce8002ce460e5474f7f00
gh api repos/jtalk/url-health-check-action/commits/v4 --jq '.sha'
# expected: b716ccb6645355dd9fcce8002ce460e5474f7f00
```
